### PR TITLE
fix pid1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host 0.0.0.0",
+    "start": "/usr/bin/tini -- ng serve --host 0.0.0.0",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
pid1で実行されないように tiniを使用

[参考サイト](https://text.superbrothers.dev/200328-how-to-avoid-pid-1-problem-in-kubernetes/)